### PR TITLE
Add unit tests for Erlang modules

### DIFF
--- a/test/peer_discovery_tests.erl
+++ b/test/peer_discovery_tests.erl
@@ -4,14 +4,20 @@
 
 start_test() ->
     ?assertEqual(ok, peer_discovery:start()),
-    ?assertEqual({error, already_started}, peer_discovery:start()).
+    ?assertEqual({error, already_started}, peer_discovery:start()),
+    ?assertException(error, _, peer_discovery:start()).
 
 stop_test() ->
     ?assertEqual(ok, peer_discovery:stop()),
-    ?assertEqual({error, not_started}, peer_discovery:stop()).
+    ?assertEqual({error, not_started}, peer_discovery:stop()),
+    ?assertException(error, _, peer_discovery:stop()).
 
 handle_message_test() ->
-    ?assertEqual(ok, peer_discovery:handle_message("Test message")).
+    ?assertEqual(ok, peer_discovery:handle_message("Test message")),
+    ?assertEqual(ok, peer_discovery:handle_message("")),
+    ?assertException(error, _, peer_discovery:handle_message(123)).
 
 broadcast_message_test() ->
-    ?assertEqual(ok, peer_discovery:broadcast_message("Test message")).
+    ?assertEqual(ok, peer_discovery:broadcast_message("Test message")),
+    ?assertEqual(ok, peer_discovery:broadcast_message("")),
+    ?assertException(error, _, peer_discovery:broadcast_message(123)).

--- a/test/reliable_transmission_tests.erl
+++ b/test/reliable_transmission_tests.erl
@@ -25,3 +25,20 @@ receive_data_with_retry_test() ->
     end,
     self() ! {data, <<"Test data">>},
     reliable_transmission:receive_data(DataHandler).
+
+send_data_invalid_peer_test() ->
+    InvalidPeer = undefined,
+    Data = <<"Test data">>,
+    ?assertException(error, _, reliable_transmission:send_data(InvalidPeer, Data)).
+
+send_data_timeout_test() ->
+    Peer = self(),
+    Data = <<"Test data">>,
+    ?assertEqual({error, retry_limit_reached}, reliable_transmission:send_data(Peer, Data, 5)).
+
+receive_data_invalid_input_test() ->
+    DataHandler = fun(Data) ->
+        ?assertEqual(<<"Test data">>, Data)
+    end,
+    self() ! {invalid_data, <<"Test data">>},
+    ?assertException(error, _, reliable_transmission:receive_data(DataHandler)).

--- a/test/video_chunking_tests.erl
+++ b/test/video_chunking_tests.erl
@@ -10,8 +10,28 @@ chunk_video_test() ->
     ?assertEqual(1048576, byte_size(lists:nth(2, Chunks))),
     ?assertEqual(1048576, byte_size(lists:nth(3, Chunks))).
 
+chunk_video_edge_case_test() ->
+    VideoPath = "path/to/non_existent_video.mp4",
+    ChunkSize = 1048576,
+    ?assertException(error, _, video_chunking:chunk_video(VideoPath, ChunkSize)).
+
+chunk_video_invalid_input_test() ->
+    VideoPath = "path/to/test_video.mp4",
+    InvalidChunkSize = -1,
+    ?assertException(error, _, video_chunking:chunk_video(VideoPath, InvalidChunkSize)).
+
 get_chunk_test() ->
     VideoPath = "path/to/test_video.mp4",
     ChunkIndex = 1,
     {ok, Chunk} = video_chunking:get_chunk(VideoPath, ChunkIndex),
     ?assertEqual(1048576, byte_size(Chunk)).
+
+get_chunk_edge_case_test() ->
+    VideoPath = "path/to/non_existent_video.mp4",
+    ChunkIndex = 1,
+    ?assertException(error, _, video_chunking:get_chunk(VideoPath, ChunkIndex)).
+
+get_chunk_invalid_input_test() ->
+    VideoPath = "path/to/test_video.mp4",
+    InvalidChunkIndex = -1,
+    ?assertException(error, _, video_chunking:get_chunk(VideoPath, InvalidChunkIndex)).


### PR DESCRIPTION
Add unit tests for edge cases and invalid inputs in `peer_discovery_tests.erl`, `reliable_transmission_tests.erl`, and `video_chunking_tests.erl`.

* **peer_discovery_tests.erl**
  - Add test cases for edge cases and invalid inputs for `start/0`, `stop/0`, `handle_message/1`, and `broadcast_message/1` functions.
  - Verify behavior for edge cases (e.g., empty messages, invalid states).
  - Ensure exceptions are raised for invalid inputs.

* **reliable_transmission_tests.erl**
  - Add test cases for edge cases and invalid inputs for `send_data/2` and `receive_data/1` functions.
  - Verify behavior for edge cases (e.g., invalid peer, timeout scenarios).
  - Ensure exceptions are raised for invalid inputs.

* **video_chunking_tests.erl**
  - Add test cases for edge cases and invalid inputs for `chunk_video/2` and `get_chunk/2` functions.
  - Verify behavior for edge cases (e.g., non-existent file, invalid chunk size).
  - Ensure exceptions are raised for invalid inputs.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/koke1997/ErlangCast?shareId=74e9938a-0b11-4a1b-afb6-d905e49dff1c).