### PR TITLE
Add local run scripts for Linux and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,3 +154,33 @@ jobs:
       - name: Run integration tests
         run: rebar3 ct --verbose
 ```
+
+## Running the Project Locally
+
+### On Linux
+
+To run the project locally on Linux, follow these steps:
+
+1. Open a terminal and navigate to the project directory.
+2. Run the installation script to install all dependencies:
+   ```sh
+   ./scripts/install_dependencies.sh
+   ```
+3. Run the project using the local run script:
+   ```sh
+   ./scripts/run_local.sh
+   ```
+
+### On Windows
+
+To run the project locally on Windows, follow these steps:
+
+1. Open a command prompt and navigate to the project directory.
+2. Run the installation script to install all dependencies:
+   ```sh
+   scripts\install_dependencies.bat
+   ```
+3. Run the project using the local run script:
+   ```sh
+   scripts\run_local.bat
+   ```

--- a/scripts/install_dependencies.bat
+++ b/scripts/install_dependencies.bat
@@ -1,0 +1,14 @@
+@echo off
+
+REM Update Chocolatey
+choco upgrade chocolatey
+
+REM Install Erlang and rebar3
+choco install erlang
+choco install rebar3
+
+REM Install ffmpeg
+choco install ffmpeg
+
+REM Print success message
+echo All dependencies have been successfully installed.

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Update package list
+sudo apt-get update
+
+# Install Erlang and rebar3
+sudo apt-get install -y erlang rebar3
+
+# Install ffmpeg
+sudo apt-get install -y ffmpeg
+
+# Print success message
+echo "All dependencies have been successfully installed."

--- a/scripts/run_local.bat
+++ b/scripts/run_local.bat
@@ -1,0 +1,15 @@
+@echo off
+
+REM Run the project locally on Windows
+
+REM Call the script to install dependencies
+call scripts\install_dependencies.bat
+
+REM Use rebar3 to compile the project
+rebar3 compile
+
+REM Use rebar3 to run the project
+rebar3 shell
+
+REM Print success message after running
+echo The project is now running locally.

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Run the project locally on Linux
+
+# Call the script to install dependencies
+./scripts/install_dependencies.sh
+
+# Use rebar3 to compile the project
+rebar3 compile
+
+# Use rebar3 to run the project
+rebar3 shell
+
+# Print success message after running
+echo "The project is now running locally."


### PR DESCRIPTION
Add scripts to run the project locally on both Windows and Linux, with installation scripts for dependencies and update the usage file with instructions.

* **Linux Scripts**
  - Add `scripts/install_dependencies.sh` to install dependencies using `apt-get`.
  - Add `scripts/run_local.sh` to run the project locally, calling the installation script and using `rebar3` to compile and run the project.

* **Windows Scripts**
  - Add `scripts/install_dependencies.bat` to install dependencies using `choco`.
  - Add `scripts/run_local.bat` to run the project locally, calling the installation script and using `rebar3` to compile and run the project.

* **README.md**
  - Update with instructions for running the project locally on both Linux and Windows.
  - Include commands to run the installation and run scripts.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/koke1997/ErlangCast?shareId=fce4db57-3b61-4bce-a475-e2e8adaad7a3).