### PR TITLE
Add RTMP streaming support to ErlangCast

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Use an official Erlang runtime as a parent image
+FROM erlang:24
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the current directory contents into the container at /app
+COPY . /app
+
+# Install dependencies
+RUN apt-get update && \
+    apt-get install -y ffmpeg libav-tools libavcodec-extra && \
+    rebar3 get-deps
+
+# Compile the project
+RUN rebar3 compile
+
+# Install Scala and sbt
+RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list && \
+    echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee /etc/apt/sources.list.d/sbt_old.list && \
+    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add && \
+    apt-get update && \
+    apt-get install -y sbt
+
+# Compile the Scala code
+RUN sbt compile
+
+# Expose the necessary ports
+EXPOSE 8080 9100-9155 9200-9255
+
+# Define the command to run the project
+CMD ["rebar3", "shell"]

--- a/README.md
+++ b/README.md
@@ -380,3 +380,48 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
 ```
+
+## RTMP Streaming Option
+The RTMP streaming option allows for real-time messaging protocol streaming, providing a stable video session for multiple users.
+
+### How to Use RTMP Streaming
+1. Ensure the `nginx-rtmp-module` and `ffmpeg` with RTMP support are installed and configured in your project.
+2. Use the `rtmp_streaming:start/2` function to start RTMP streaming with the video file path and output directory as arguments.
+3. Retrieve the RTMP stream URL using the `rtmp_streaming:get_stream_url/1` function with the output directory as an argument.
+
+### Example
+```erlang
+% Start RTMP streaming
+rtmp_streaming:start("path/to/video.mp4", "path/to/output").
+
+% Retrieve the RTMP stream URL
+{ok, StreamURL} = rtmp_streaming:get_stream_url("path/to/output").
+```
+
+## Troubleshooting Common Issues
+This section provides solutions to common issues that users might encounter during setup and running the project.
+
+### Issue: Dependencies not installed correctly
+**Solution**: Ensure that the installation scripts (`scripts/install_dependencies.sh` and `scripts/install_dependencies.bat`) are up-to-date and cover all necessary dependencies for the project, including those required for RTMP streaming.
+
+### Issue: Video streaming not working
+**Solution**: Check the configuration files and ensure that the necessary libraries and tools for HLS, DASH, and RTMP streaming are installed and configured correctly. Verify that the video file paths and output directories are correct.
+
+### Issue: Project not running locally
+**Solution**: Follow the detailed instructions in the `README.md` for setting up and running the project locally on different platforms. Ensure that all dependencies are installed, and the project is compiled correctly.
+
+## Running the Project with Docker
+
+To build and run the project using Docker, follow these steps:
+
+1. Build the Docker image:
+   ```sh
+   docker build -t erlangcast .
+   ```
+
+2. Run the Docker container:
+   ```sh
+   docker run -p 8080:8080 -p 9100-9155:9100-9155 -p 9200-9255:9200-9255 erlangcast
+   ```
+
+This will start the ErlangCast project in a Docker container, making it easy to run locally.

--- a/config/rebar.config
+++ b/config/rebar.config
@@ -5,5 +5,7 @@
     {jsx, "2.11.0"},
     {ffmpeg, "4.4.0"},
     {hls, "1.0.0"},
-    {dash, "1.0.0"}
+    {dash, "1.0.0"},
+    {nginx_rtmp_module, "1.2.1"},
+    {ffmpeg_rtmp, "4.4.0"}
 ]}.

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,6 +30,7 @@
         <option value="webcam">Webcam</option>
         <option value="hls">HLS</option>
         <option value="dash">DASH</option>
+        <option value="rtmp">RTMP</option>
     </select>
     <select id="user1Camera">
         <option value="">Select Camera for User 1</option>
@@ -83,6 +84,9 @@
                 videoElement.play();
             } else if (selectedOption === 'dash') {
                 videoElement.src = 'path/to/dash/manifest.mpd';
+                videoElement.play();
+            } else if (selectedOption === 'rtmp') {
+                videoElement.src = 'rtmp://localhost/live/stream';
                 videoElement.play();
             }
         });

--- a/scripts/install_dependencies.bat
+++ b/scripts/install_dependencies.bat
@@ -14,5 +14,9 @@ REM Install HLS and DASH dependencies
 choco install libav-tools
 choco install libavcodec-extra
 
+REM Install nginx-rtmp-module
+choco install nginx
+choco install nginx-rtmp-module
+
 REM Print success message
 echo All dependencies have been successfully installed.

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -13,5 +13,8 @@ sudo apt-get install -y ffmpeg
 sudo apt-get install -y libav-tools
 sudo apt-get install -y libavcodec-extra
 
+# Install nginx-rtmp-module
+sudo apt-get install -y nginx nginx-rtmp-module
+
 # Print success message
 echo "All dependencies have been successfully installed."


### PR DESCRIPTION
Add support for RTMP streaming and Docker setup for ErlangCast project.

* **RTMP Streaming:**
  - Add `nginx_rtmp_module` and `ffmpeg_rtmp` dependencies in `config/rebar.config`.
  - Add RTMP option in `docs/index.html` and update event listener to handle RTMP streaming.
  - Update `README.md` with instructions for RTMP streaming, troubleshooting, and Docker setup.

* **Docker Setup:**
  - Add `Dockerfile` to define Docker image, install dependencies, compile project, and expose necessary ports.

* **Dependency Installation:**
  - Update `scripts/install_dependencies.sh` and `scripts/install_dependencies.bat` to include `nginx-rtmp-module` installation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/koke1997/ErlangCast?shareId=a6ce8e25-764c-49aa-8e33-1e590ff63a15).